### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# auto detected text files and normalize line endings based on OS
+* text=auto
+
+# Ignore for archiving and composer package
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore
+/docs export-ignore
+
+# Optimize Git diffs for PHP files
+*.php text diff=php


### PR DESCRIPTION
we don't need the `tests` or `docs` folder when this project is exported for production distribution
